### PR TITLE
[cccInterface Plugin] Anpassung expectedCloseCodes

### DIFF
--- a/js/plugins/CCCInterface.jsx
+++ b/js/plugins/CCCInterface.jsx
@@ -71,7 +71,7 @@ class CCCInterface extends React.Component {
         zoomToPoint: PropTypes.func
     };
     static defaultProps = {
-        expectedCloseCodes: [1000, 1001, 1008, 1012]
+        expectedCloseCodes: [1000, 1001, 1008, 1012, 1013]
     };
     constructor(props) {
         super(props);


### PR DESCRIPTION
Der `ccc-service` ab v1.2.4 kann neu mit `CloseStatus.SERVICE_OVERLOAD` (1013) antworten. In diesem Fall darf vom Web GIS Client aus kein Reconnect-Versuch erfolgen.

Abhängigkeit: https://github.com/sogis/ccc-service